### PR TITLE
Add optional server-side stream filters (quality, sort)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ docker-compose up -d
 | `PROWLARR_API_KEY` | No | - | Optional API key for Prowlarr authentication |
 | `DEFAULT_SEARCH_LIMIT` | No | 100 | Default number of results to return |
 | `MAX_SEARCH_LIMIT` | No | 1000 | Maximum allowed search results |
+| `ORIONOID_VIDEO_QUALITY` | No | _(unset)_ | Comma-separated Orionoid video qualities to request, e.g. `hd4k,hd2k,hd1080`. Filters server-side, so low-quality releases never count against the daily stream quota. Accepted: `hd8k`, `hd6k`, `hd4k`, `hd2k`, `hd1080`, `hd720`, `sd`, `scr1080`, `scr720`, `scr`, `cam1080`, `cam720`, `cam` |
+| `ORIONOID_SORT` | No | best | Orionoid sort order: `none`, `shuffle`, `best`, `popularity`, `timeupdated`, `filesize`, `streamseeds`, `videoquality`, `audiochannels` |
 | `LOG_LEVEL` | No | INFO | Logging level (DEBUG, INFO, WARNING, ERROR) |
 
 ## Adding to Prowlarr

--- a/config.py
+++ b/config.py
@@ -26,6 +26,19 @@ class Settings(BaseSettings):
     default_search_limit: int = 100
     max_search_limit: int = 1000
 
+    # Server-side stream filtering.
+    # Orionoid can filter before returning results, which keeps the response
+    # focused and avoids spending the account's daily stream quota on releases
+    # that will be discarded downstream anyway (e.g. CAM/screener rips).
+    # Comma-separated list of Orionoid video qualities, e.g. "hd4k,hd2k,hd1080".
+    # Leave unset to keep the previous behaviour (no quality filtering).
+    # Accepted: hd8k, hd6k, hd4k, hd2k, hd1080, hd720, sd,
+    #           scr1080, scr720, scr, cam1080, cam720, cam
+    orionoid_video_quality: Optional[str] = None
+    # Orionoid sort order. Accepted: none, shuffle, best, popularity,
+    # timeupdated, filesize, streamseeds, videoquality, audiochannels
+    orionoid_sort: str = "best"
+
     # Logging
     log_level: str = "INFO"
 

--- a/main.py
+++ b/main.py
@@ -420,6 +420,12 @@ async def search_orionoid(
             season=season,
             episode=episode,
             limit=limit,
+            video_quality=(
+                [q.strip() for q in settings.orionoid_video_quality.split(",") if q.strip()]
+                if settings.orionoid_video_quality
+                else None
+            ),
+            sort=settings.orionoid_sort,
         )
     except Exception as e:
         _update_api_status(healthy=False, message=str(e))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,6 +21,29 @@ class TestCapabilities:
         assert searching.find("movie-search") is not None
 
 
+class TestStreamFilters:
+    """Server-side filters are forwarded to Orionoid (see config.Settings)."""
+
+    async def test_sort_is_forwarded(self, test_client, mock_search, reset_globals):
+        await test_client.get("/api?t=movie&q=test")
+        assert mock_search.call_args.kwargs["sort"] == "best"
+
+    async def test_video_quality_unset_by_default(
+        self, test_client, mock_search, reset_globals
+    ):
+        await test_client.get("/api?t=movie&q=test")
+        assert mock_search.call_args.kwargs["video_quality"] is None
+
+    async def test_video_quality_is_parsed_into_list(
+        self, test_client, mock_search, reset_globals, monkeypatch
+    ):
+        from config import settings
+
+        monkeypatch.setattr(settings, "orionoid_video_quality", "hd4k, hd1080 ,")
+        await test_client.get("/api?t=movie&q=test")
+        assert mock_search.call_args.kwargs["video_quality"] == ["hd4k", "hd1080"]
+
+
 class TestSearch:
     async def test_movie_search(self, test_client, mock_search, reset_globals):
         await test_client.get("/api?t=movie&q=test")


### PR DESCRIPTION
## Problem

`OrionoidClient.search_streams()` already accepts `video_quality` and `sort`, but `main.py` never passes them. Every search therefore retrieves Orionoid's unfiltered default set.

On a metered plan this is expensive: CAM/screener/SD releases are retrieved and counted against the daily stream quota even when the consuming application (Prowlarr → Sonarr/Radarr/etc.) discards them immediately. Filtering client-side cannot recover that cost — the streams have already been spent.

## Change

Two optional settings, both defaulting to the current behaviour:

| Setting | Default | Effect |
|---|---|---|
| `ORIONOID_VIDEO_QUALITY` | _(unset)_ | Comma-separated qualities, e.g. `hd4k,hd2k,hd1080`. Unset means no quality filtering, exactly as today. |
| `ORIONOID_SORT` | `best` | Same value the client already used by default. |

Because Orionoid applies the filter, unwanted releases are never retrieved and never counted.

## Notes

- Fully backwards compatible: with neither variable set, the request Orionoid receives is byte-identical to before.
- Added to the README env table.
- Tests cover forwarding of both values and parsing/trimming of the comma-separated list.
- Deliberately did **not** run `ruff format` over the repo: `config.py` and `tests/test_api.py` already fail `ruff format --check` on `main`, and reformatting them would bury this change in noise. `ruff check` passes.
- Full suite: 28 passed.